### PR TITLE
Dropped test run time from 3 minutes to 3 seconds

### DIFF
--- a/ProductFlatChangelogTest.php
+++ b/ProductFlatChangelogTest.php
@@ -5,31 +5,31 @@
  * products will actually be processed correctly while Magento will effectively skip the remainder
  * of the products. Despite skipping some products, Magento will mark the changelog as being fully
  * processed, meaning some products will indefinitely remain out of date in the product flat tables.
- *
+ * 
  * This test script can be run against a Magento Enterprise installation and proves this bug. This
  * script should not be run on a production environment.
- *
+ * 
  * @author Josh Di Fabio <jd@amp.co>
  */
 class ProductFlatChangelogTest extends PHPUnit_Framework_TestCase
 {
     private $indexTable;
     private $changelogTable;
-
+    
     public function __construct($name = null, array $data = array(), $dataName = '')
     {
         parent::__construct($name, $data, $dataName);
-
+        
         Mage::app();
-
+        
         $connection = Mage::getSingleton('core/resource')
             ->getConnection(Mage_Core_Model_Resource::DEFAULT_READ_RESOURCE);
-
+        
         $this->indexTable = new Zend_Db_Table(array(
             'db' => $connection,
             'name' => Mage::helper('enterprise_catalog/product')->getFlatTableName(1),
         ));
-
+        
         $this->changelogTable = new Zend_Db_Table(array(
             'db' => $connection,
             'name' => 'catalog_product_flat_cl',
@@ -40,7 +40,7 @@ class ProductFlatChangelogTest extends PHPUnit_Framework_TestCase
             'name' => 'catalog_product_entity',
         ));
     }
-
+    
     public function testMoreThan500Changes()
     {
         // ensure a full re-index does not run for the duration of this test
@@ -49,7 +49,7 @@ class ProductFlatChangelogTest extends PHPUnit_Framework_TestCase
         }
 
         $description = 'Mage EE product flat index bug test script created this product: ' . now();
-
+        
         try {
             $this->enableFlatTable();
             $this->disableLiveReindex();
@@ -67,22 +67,22 @@ class ProductFlatChangelogTest extends PHPUnit_Framework_TestCase
 
         $this->releaseReindexLock();
     }
-
+    
     private function acquireReindexLock()
     {
         return Enterprise_Index_Model_Lock::getInstance()->setLock(Enterprise_Index_Model_Observer::REINDEX_FULL_LOCK);
     }
-
+    
     private function releaseReindexLock()
     {
         Enterprise_Index_Model_Lock::getInstance()->releaseLock(Enterprise_Index_Model_Observer::REINDEX_FULL_LOCK);
     }
-
+    
     private function enableFlatTable()
     {
         Mage::getConfig()->setNode('default/catalog/frontend/flat_catalog_product', 1);
     }
-
+    
     private function disableLiveReindex()
     {
         Mage::app()->getStore()->setConfig(
@@ -90,7 +90,7 @@ class ProductFlatChangelogTest extends PHPUnit_Framework_TestCase
             0
         );
     }
-
+    
     /**
      * @author Joseph McDermott <code@josephmcdermott.co.uk>
      */
@@ -104,7 +104,7 @@ class ProductFlatChangelogTest extends PHPUnit_Framework_TestCase
 
         return $productId;
     }
-
+    
     /**
      * @author Joseph McDermott <code@josephmcdermott.co.uk>
      */
@@ -120,7 +120,7 @@ class ProductFlatChangelogTest extends PHPUnit_Framework_TestCase
             ));
         }
     }
-
+    
     private function createProducts($description, $limit)
     {
         $createdProductIds = array();
@@ -144,27 +144,27 @@ class ProductFlatChangelogTest extends PHPUnit_Framework_TestCase
                 )
             );
         }
-
+        
         return $createdProductIds;
     }
-
+    
     private function processChangelog()
     {
         $indexerData = Mage::getConfig()->getNode(
             Enterprise_Index_Helper_Data::XML_PATH_INDEXER_DATA . '/catalog_product_flat'
         );
-
+        
         $client = Mage::getModel('enterprise_mview/client')
             ->init((string)$indexerData->index_table);
-
+        
         $metadata = $client->getMetadata();
-
+        
         do {
             $client->execute((string)$indexerData->action_model->changelog);
             $metadata->load($metadata->getId());
         } while ($metadata->getVersionId() < $this->getMaxVersionId());
     }
-
+    
     private function validateFlatTable(array $productIds, $description)
     {
         foreach ($productIds as $sku => $productId) {
@@ -177,14 +177,14 @@ class ProductFlatChangelogTest extends PHPUnit_Framework_TestCase
             );
         }
     }
-
+    
     private function getMaxVersionId()
     {
         $result = $this->changelogTable->select(Zend_Db_Table::SELECT_WITH_FROM_PART)
             ->columns(array('max_version_id' => 'MAX(version_id)'))
             ->query()
                 ->fetchObject();
-
+        
         return $result->max_version_id;
     }
 }

--- a/ProductFlatChangelogTest.php
+++ b/ProductFlatChangelogTest.php
@@ -5,37 +5,42 @@
  * products will actually be processed correctly while Magento will effectively skip the remainder
  * of the products. Despite skipping some products, Magento will mark the changelog as being fully
  * processed, meaning some products will indefinitely remain out of date in the product flat tables.
- * 
+ *
  * This test script can be run against a Magento Enterprise installation and proves this bug. This
  * script should not be run on a production environment.
- * 
+ *
  * @author Josh Di Fabio <jd@amp.co>
  */
 class ProductFlatChangelogTest extends PHPUnit_Framework_TestCase
 {
     private $indexTable;
     private $changelogTable;
-    
+
     public function __construct($name = null, array $data = array(), $dataName = '')
     {
         parent::__construct($name, $data, $dataName);
-        
+
         Mage::app();
-        
+
         $connection = Mage::getSingleton('core/resource')
             ->getConnection(Mage_Core_Model_Resource::DEFAULT_READ_RESOURCE);
-        
+
         $this->indexTable = new Zend_Db_Table(array(
             'db' => $connection,
             'name' => Mage::helper('enterprise_catalog/product')->getFlatTableName(1),
         ));
-        
+
         $this->changelogTable = new Zend_Db_Table(array(
             'db' => $connection,
             'name' => 'catalog_product_flat_cl',
         ));
+
+        $this->productTable = new Zend_Db_Table(array(
+            'db' => $connection,
+            'name' => 'catalog_product_entity',
+        ));
     }
-    
+
     public function testMoreThan500Changes()
     {
         // ensure a full re-index does not run for the duration of this test
@@ -44,11 +49,15 @@ class ProductFlatChangelogTest extends PHPUnit_Framework_TestCase
         }
 
         $description = 'Mage EE product flat index bug test script created this product: ' . now();
-        
+
         try {
             $this->enableFlatTable();
             $this->disableLiveReindex();
-            $productIds = $this->createProducts($description, 550);
+
+            $entityId = $this->getNewestProductId();
+            $this->simulate500changes($entityId);
+            $productIds = $this->createProducts($description, 1);
+
             $this->processChangelog();
             $this->validateFlatTable($productIds, $description);
         } catch (Exception $e) {
@@ -58,22 +67,22 @@ class ProductFlatChangelogTest extends PHPUnit_Framework_TestCase
 
         $this->releaseReindexLock();
     }
-    
+
     private function acquireReindexLock()
     {
         return Enterprise_Index_Model_Lock::getInstance()->setLock(Enterprise_Index_Model_Observer::REINDEX_FULL_LOCK);
     }
-    
+
     private function releaseReindexLock()
     {
         Enterprise_Index_Model_Lock::getInstance()->releaseLock(Enterprise_Index_Model_Observer::REINDEX_FULL_LOCK);
     }
-    
+
     private function enableFlatTable()
     {
         Mage::getConfig()->setNode('default/catalog/frontend/flat_catalog_product', 1);
     }
-    
+
     private function disableLiveReindex()
     {
         Mage::app()->getStore()->setConfig(
@@ -81,7 +90,37 @@ class ProductFlatChangelogTest extends PHPUnit_Framework_TestCase
             0
         );
     }
-    
+
+    /**
+     * @author Joseph McDermott <code@josephmcdermott.co.uk>
+     */
+    private function getNewestProductId()
+    {
+        $productId = $this->productTable->select(Zend_Db_Table::SELECT_WITH_FROM_PART)
+            ->columns(array('entity_id'))
+            ->order('entity_id DESC')
+            ->query()
+            ->fetchColumn();
+
+        return $productId;
+    }
+
+    /**
+     * @author Joseph McDermott <code@josephmcdermott.co.uk>
+     */
+    private function simulate500changes($startEntityId)
+    {
+        // skip the ID that our new product will use
+        $startEntityId += 2;
+
+        for ($i = $startEntityId; $i < $startEntityId + 550; $i++) {
+            $this->changelogTable->insert(array(
+                'version_id' => NULL,
+                'entity_id' => $i,
+            ));
+        }
+    }
+
     private function createProducts($description, $limit)
     {
         $createdProductIds = array();
@@ -105,27 +144,27 @@ class ProductFlatChangelogTest extends PHPUnit_Framework_TestCase
                 )
             );
         }
-        
+
         return $createdProductIds;
     }
-    
+
     private function processChangelog()
     {
         $indexerData = Mage::getConfig()->getNode(
             Enterprise_Index_Helper_Data::XML_PATH_INDEXER_DATA . '/catalog_product_flat'
         );
-        
+
         $client = Mage::getModel('enterprise_mview/client')
             ->init((string)$indexerData->index_table);
-        
+
         $metadata = $client->getMetadata();
-        
+
         do {
             $client->execute((string)$indexerData->action_model->changelog);
             $metadata->load($metadata->getId());
         } while ($metadata->getVersionId() < $this->getMaxVersionId());
     }
-    
+
     private function validateFlatTable(array $productIds, $description)
     {
         foreach ($productIds as $sku => $productId) {
@@ -138,14 +177,14 @@ class ProductFlatChangelogTest extends PHPUnit_Framework_TestCase
             );
         }
     }
-    
+
     private function getMaxVersionId()
     {
         $result = $this->changelogTable->select(Zend_Db_Table::SELECT_WITH_FROM_PART)
             ->columns(array('max_version_id' => 'MAX(version_id)'))
             ->query()
                 ->fetchObject();
-        
+
         return $result->max_version_id;
     }
 }

--- a/ProductFlatChangelogTest.php
+++ b/ProductFlatChangelogTest.php
@@ -54,8 +54,11 @@ class ProductFlatChangelogTest extends PHPUnit_Framework_TestCase
             $this->enableFlatTable();
             $this->disableLiveReindex();
 
-            $entityId = $this->getNewestProductId();
-            $this->simulate500changes($entityId);
+            $lastProductId = $this->getLastProductId();
+            
+            // skip the ID that our new product will use
+            $this->simulate500changes($lastProductId + 2);
+            
             $productIds = $this->createProducts($description, 1);
 
             $this->processChangelog();
@@ -94,7 +97,7 @@ class ProductFlatChangelogTest extends PHPUnit_Framework_TestCase
     /**
      * @author Joseph McDermott <code@josephmcdermott.co.uk>
      */
-    private function getNewestProductId()
+    private function getLastProductId()
     {
         $productId = $this->productTable->select(Zend_Db_Table::SELECT_WITH_FROM_PART)
             ->columns(array('entity_id'))
@@ -110,9 +113,6 @@ class ProductFlatChangelogTest extends PHPUnit_Framework_TestCase
      */
     private function simulate500changes($startEntityId)
     {
-        // skip the ID that our new product will use
-        $startEntityId += 2;
-
         for ($i = $startEntityId; $i < $startEntityId + 550; $i++) {
             $this->changelogTable->insert(array(
                 'version_id' => NULL,


### PR DESCRIPTION
Rather than creating 550 products, the test will now inject 550 entries in to the changelog table and then create a single product afterwards. The result should be the same, ie. more than 500 entries in the changelog table with our single test product not being one of them.
